### PR TITLE
Removed unnecessary rotation handling

### DIFF
--- a/UIView+Positioning.m
+++ b/UIView+Positioning.m
@@ -134,12 +134,13 @@
 }
 
 // Methods
--(void)centerToParent{
-    if (!self.superview) {
-        return;
+- (void)centerToParent {
+    if (!self.superview) {
+        return;
     }
-    self.x = (self.superview.width / 2.0) - (self.width / 2.0);
-    self.y = (self.superview.height / 2.0) - (self.height / 2.0);
+    
+    self.x = (self.superview.height / 2.0) - (self.width / 2.0);
+    self.y = (self.superview.height / 2.0) - (self.height / 2.0);
 }
 
 @end

--- a/UIView+Positioning.m
+++ b/UIView+Positioning.m
@@ -135,22 +135,11 @@
 
 // Methods
 -(void)centerToParent{
-    if(self.superview){
-        switch ([UIApplication sharedApplication].statusBarOrientation){
-            case UIInterfaceOrientationLandscapeLeft:
-            case UIInterfaceOrientationLandscapeRight:{
-                self.x  =   PIXEL_INTEGRAL((self.superview.height / 2.0) - (self.width / 2.0));
-                self.y  =   PIXEL_INTEGRAL((self.superview.width / 2.0) - (self.height / 2.0));
-                break;
-            }
-            case UIInterfaceOrientationPortrait:
-            case UIInterfaceOrientationPortraitUpsideDown:{
-                self.x  =   PIXEL_INTEGRAL((self.superview.width / 2.0) - (self.width / 2.0));
-                self.y  =   PIXEL_INTEGRAL((self.superview.height / 2.0) - (self.height / 2.0));
-                break;
-            }
-        }
+    if (!self.superview) {
+        return;
     }
+    self.x = (self.superview.width / 2.0) - (self.width / 2.0);
+    self.y = (self.superview.height / 2.0) - (self.height / 2.0);
 }
 
 @end


### PR DESCRIPTION
All main view-related frame adjustments should be done in viewDidLayoutSubviews, and by switching for rotation, the values are actually wrong in viewDidLayoutSubviews. Also, since pixel integral happens in setX: and setY:, those calls within centerToParent were redundant.