### PR TITLE
feat(objc): add explicit @objc annotation

### DIFF
--- a/UIView+Positioning.swift
+++ b/UIView+Positioning.swift
@@ -11,6 +11,7 @@ public extension UIView {
     // MARK: - Basic Properties
 
     /// X Axis value of UIView.
+    @objc
     var x: CGFloat {
         set { self.frame = CGRect(x: _pixelIntegral(newValue),
                                   y: self.y,
@@ -21,6 +22,7 @@ public extension UIView {
     }
 
     /// Y Axis value of UIView.
+    @objc
     var y: CGFloat {
         set { self.frame = CGRect(x: self.x,
                                   y: _pixelIntegral(newValue),
@@ -31,6 +33,7 @@ public extension UIView {
     }
 
     /// Width of view.
+    @objc
     var width: CGFloat {
         set { self.frame = CGRect(x: self.x,
                                   y: self.y,
@@ -41,6 +44,7 @@ public extension UIView {
     }
 
     /// Height of view.
+    @objc
     var height: CGFloat {
         set { self.frame = CGRect(x: self.x,
                                   y: self.y,
@@ -53,6 +57,7 @@ public extension UIView {
     // MARK: - Origin and Size
 
     /// View's Origin point.
+    @objc
     var origin: CGPoint {
         set { self.frame = CGRect(x: _pixelIntegral(newValue.x),
                                   y: _pixelIntegral(newValue.y),
@@ -63,6 +68,7 @@ public extension UIView {
     }
 
     /// View's size.
+    @objc
     var size: CGSize {
         set { self.frame = CGRect(x: self.x,
                                   y: self.y,
@@ -75,42 +81,49 @@ public extension UIView {
     // MARK: - Extra Properties
 
     /// View's right side (x + width).
+    @objc
     var right: CGFloat {
         set { self.x = newValue - self.width }
         get { return self.x + self.width }
     }
 
     /// View's bottom (y + height).
+    @objc
     var bottom: CGFloat {
         set { self.y = newValue - self.height }
         get { return self.y + self.height }
     }
 
     /// View's top (y).
+    @objc
     var top: CGFloat {
         set { self.y = newValue }
         get { return self.y }
     }
 
     /// View's left side (x).
+    @objc
     var left: CGFloat {
         set { self.x = newValue }
         get { return self.x }
     }
 
     /// View's center X value (center.x).
+    @objc
     var centerX: CGFloat {
         set { self.center = CGPoint(x: newValue, y: self.centerY) }
         get { return self.center.x }
     }
 
     /// View's center Y value (center.y).
+    @objc
     var centerY: CGFloat {
         set { self.center = CGPoint(x: self.centerX, y: newValue) }
         get { return self.center.y }
     }
 
     /// Last subview on X Axis.
+    @objc
     var lastSubviewOnX: UIView? {
         return self.subviews.reduce(UIView(frame: .zero)) {
             return $1.x > $0.x ? $1 : $0
@@ -118,6 +131,7 @@ public extension UIView {
     }
 
     /// Last subview on Y Axis.
+    @objc
     var lastSubviewOnY: UIView? {
         return self.subviews.reduce(UIView(frame: .zero)) {
             return $1.y > $0.y ? $1 : $0
@@ -127,6 +141,7 @@ public extension UIView {
     // MARK: - Bounds Methods
 
     /// X value of bounds (bounds.origin.x).
+    @objc
     var boundsX: CGFloat {
         set { self.bounds = CGRect(x: _pixelIntegral(newValue),
                                    y: self.boundsY,
@@ -137,6 +152,7 @@ public extension UIView {
     }
 
     /// Y value of bounds (bounds.origin.y).
+    @objc
     var boundsY: CGFloat {
         set { self.frame = CGRect(x: self.boundsX,
                                   y: _pixelIntegral(newValue),
@@ -147,6 +163,7 @@ public extension UIView {
     }
 
     /// Width of bounds (bounds.size.width).
+    @objc
     var boundsWidth: CGFloat {
         set { self.frame = CGRect(x: self.boundsX,
                                   y: self.boundsY,
@@ -157,6 +174,7 @@ public extension UIView {
     }
 
     /// Height of bounds (bounds.size.height).
+    @objc
     var boundsHeight: CGFloat {
         set { self.frame = CGRect(x: self.boundsX,
                                   y: self.boundsY,
@@ -169,6 +187,7 @@ public extension UIView {
     // MARK: - Useful Methods
 
     /// Center view to it's parent view.
+    @objc
     func centerToParent() {
         guard let superview = self.superview else { return }
 


### PR DESCRIPTION
This was the default behaviour in Swift 3 - the compiler inferred all these annotations automatically.
Now in Swift 4, the compiler does not automatically infer these anymore and its necessary to explicitly add these @objc annotations to methods that should be available in ObjC.